### PR TITLE
Hide keyboard when tapped outside of the search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+- Lose focus on the search field if tapped outside of it.
+
 ## 1.7.0
 
 - Add `showSearch` to `FancyDioInspectorTileOptions` in order to be able to toggle the search field. [#9](https://github.com/gokhancvs/fancy_dio_inspector/pull/9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-- Lose focus on the search field if tapped outside of it.
+- Unfocus search field when tapped outside of it.
 
 ## 1.7.0
 

--- a/lib/src/ui/widgets/fancy_search_field.dart
+++ b/lib/src/ui/widgets/fancy_search_field.dart
@@ -32,6 +32,7 @@ class _FancySearchFieldState extends State<FancySearchField> {
   @override
   Widget build(BuildContext context) {
     return TextField(
+      onTapOutside: (_) => FocusScope.of(context).unfocus(),
       controller: _controller,
       onChanged: widget.onChanged,
       decoration: InputDecoration(


### PR DESCRIPTION
Just a minor pull request.

Just added one line to the FancySearchField to lose focus when the user taps outside of the search field.
Otherwise the keyboard would remain open, even when the tab was changed.