### PR TITLE
Remove clear button if search field is empty

### DIFF
--- a/lib/src/ui/widgets/fancy_search_field.dart
+++ b/lib/src/ui/widgets/fancy_search_field.dart
@@ -38,11 +38,13 @@ class _FancySearchFieldState extends State<FancySearchField> {
       decoration: InputDecoration(
         hintText: widget.hintText,
         prefixIcon: const Icon(Icons.search),
-        suffixIcon: _controller.text.isNotEmpty ? GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: _onClearPressed,
-          child: const Icon(Icons.close),
-        ) : null,
+        suffixIcon: _controller.text.isEmpty
+            ? null
+            : GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: _onClearPressed,
+                child: const Icon(Icons.close),
+              ),
       ),
     );
   }

--- a/lib/src/ui/widgets/fancy_search_field.dart
+++ b/lib/src/ui/widgets/fancy_search_field.dart
@@ -37,11 +37,11 @@ class _FancySearchFieldState extends State<FancySearchField> {
       decoration: InputDecoration(
         hintText: widget.hintText,
         prefixIcon: const Icon(Icons.search),
-        suffixIcon: GestureDetector(
+        suffixIcon: _controller.text.isNotEmpty ? GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: _onClearPressed,
           child: const Icon(Icons.close),
-        ),
+        ) : null,
       ),
     );
   }


### PR DESCRIPTION
Just a very little visual change
The clear button does not have any effect, when the controller text is empty, so why show it?