### PR TITLE
fix: cURL generate for contentType of Headers.formUrlEncodedContentType

### DIFF
--- a/lib/src/utils/extensions/request_extensions.dart
+++ b/lib/src/utils/extensions/request_extensions.dart
@@ -78,7 +78,13 @@ extension CurlExtension on RequestOptions {
         } else if (data is Map<String, dynamic>) {
           files.addAll(data as Map<String, dynamic>);
 
-          if (files.isNotEmpty) {
+          if (headers.containsValue(Headers.formUrlEncodedContentType)) {
+            final encodeData = files.entries.map((entry) {
+              // 使用 Uri.encodeQueryComponent 进行编码
+              return '${Uri.encodeQueryComponent(entry.key)}=${Uri.encodeQueryComponent(entry.value.toString())}';
+            }).join('&');
+            postData = "-d '$encodeData'";
+          } else if (files.isNotEmpty) {
             postData = "-d '${json.encode(files)}'";
           }
         }


### PR DESCRIPTION
For contentType of Headers.formUrlEncodedContentType

the old cURL is: 
curl -X POST -d '{"deviceId":"6B584C11-935E-46E7-A87D","format":"rsa"}' -H 'content-type: application/x-www-form-urlencoded' -H 'content-length: 123' 'https://a.b.com/api'

the new cURL is 
curl -X POST -d 'deviceId=6B584C11-935E-46E7-A87D&format=rsa' -H 'content-type: application/x-www-form-urlencoded' -H 'content-length: 123' 'https://a.b.com/api'
