### PR TITLE
Updated “fancy_theme_data.dart” for Flutter version 3.32.2

### DIFF
--- a/lib/src/theme/fancy_theme_data.dart
+++ b/lib/src/theme/fancy_theme_data.dart
@@ -5,7 +5,6 @@ mixin FancyThemeData {
   static final ThemeData light = ThemeData.light().copyWith(
     colorScheme: ColorScheme.fromSeed(seedColor: FancyColors.turquoise),
     primaryColor: FancyColors.turquoise,
-    indicatorColor: FancyColors.darkCyan,
     appBarTheme: const AppBarTheme(
       backgroundColor: FancyColors.turquoise,
       elevation: 0,
@@ -14,9 +13,10 @@ mixin FancyThemeData {
       backgroundColor: FancyColors.turquoise,
       elevation: 0,
     ),
-    tabBarTheme: const TabBarTheme(
+    tabBarTheme: const TabBarThemeData(
       labelColor: FancyColors.white,
       unselectedLabelColor: FancyColors.white,
+      indicatorColor: FancyColors.darkCyan,
     ),
     textSelectionTheme: const TextSelectionThemeData(
       cursorColor: FancyColors.turquoise,


### PR DESCRIPTION
- In Flutter version 3.32.2, the use of “TabBarTheme” has been removed, so it has been updated to “TabBarThemeData”.
- Now, instead of giving indicatorColor in the theme, it is requested to be given in TabBarThemeData, I updated it.